### PR TITLE
Add response data to vault api error

### DIFF
--- a/src/VaultApiClient.js
+++ b/src/VaultApiClient.js
@@ -4,6 +4,8 @@ const axios = require('axios');
 const urljoin = require('url-join');
 const _ = require('lodash');
 
+const errors = require('./errors')
+
 class VaultApiClient {
 
     /**
@@ -45,6 +47,24 @@ class VaultApiClient {
                     JSON.stringify(response.data, null, ' ')
                 );
                 return response.data;
+            })
+            .catch((err) => {
+                if (err.response) {
+                    this._logger.error('%s %s response status: %s response body:\n%s',
+                        requestOptions.method,
+                        requestOptions.url,
+                        err.response.status,
+                        JSON.stringify(err.response.data, null, ' ')
+                    );
+                    throw new errors.VaultApiError(`Request to Vault failed with ${err.response.status} response: ${JSON.stringify(err.response.data)}`);
+                } else {
+                    this._logger.error('%s %s error: %s',
+                        requestOptions.method,
+                        requestOptions.url,
+                        err.message
+                    );
+                    throw new errors.VaultApiError(`Request to Vault failed with error: ${err.message}`)
+                }
             });
     }
 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -12,10 +12,12 @@ class VaultError extends Error {
 class InvalidArgumentsError extends VaultError {}
 class InvalidAWSCredentialsError extends InvalidArgumentsError {}
 class AuthTokenExpiredError extends VaultError {}
+class VaultApiError extends VaultError {}
 
 module.exports = {
     VaultError,
     InvalidArgumentsError,
     InvalidAWSCredentialsError,
     AuthTokenExpiredError,
+    VaultApiError,
 };


### PR DESCRIPTION
When an API error occurs (either a non-2xx response or a request error), we should include the response body and status (if available) in the thrown error.